### PR TITLE
Correct linux binary name and output path

### DIFF
--- a/ci/build-linux
+++ b/ci/build-linux
@@ -9,5 +9,5 @@ go get github.com/jteeuwen/go-bindata/go-bindata
 
 ./gopath/src/github.com/vito/concourse-bin/scripts/build
 
-go build -o darwin-binary/concourse_darwin_amd64 \
+go build -o linux-binary/concourse_linux_amd64 \
   github.com/vito/concourse-bin/cmd/concourse


### PR DESCRIPTION
Suspect this hasn't been tested. Will currently stomp all over the darwin builds when doing a full release build.
