### PR TITLE
release binaries to repo in concourse org

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -27,7 +27,7 @@ resources:
 - name: bin-releases
   type: github-release
   source:
-    user: vito
+    user: concourse
     repository: bin
     access_token: {{release-token}}
 


### PR DESCRIPTION
Not sure but seems to me like this is on oversight, there is no `bin` repository in the `vito` org.
