### PR TITLE
Fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ concourse web \
   --session-signing-key session_signing_key \
   --tsa-host-key host_key \
   --tsa-authorized-keys authorized_worker_keys
-  --postgres-data-source postgres://user:pass@10.0.32.0/concourse \
+  --postgres-data-source postgres://user:pass@10.0.32.0/atc \
   --external-url https://ci.example.com \
   --peer-url http://10.0.16.10:8080
 ```
@@ -117,7 +117,7 @@ concourse web \
   --session-signing-key session_signing_key \
   --tsa-host-key host_key \
   --tsa-authorized-keys authorized_worker_keys
-  --postgres-data-source postgres://user:pass@10.0.32.0/concourse \
+  --postgres-data-source postgres://user:pass@10.0.32.0/atc \
   --external-url https://ci.example.com \
   --peer-url http://10.0.16.11:8080
 ```


### PR DESCRIPTION
This pull request is related to [my pull request to Concourse CI documentation](https://github.com/concourse/concourse/pull/437).

According to [the comments in ATC source codes](https://github.com/concourse/atc/blob/master/atccmd/command.go#L60), `postgres://user:pass@10.0.32.0/concourse` is wrong for the parameter of `--postgres-data-source` option. The end of the parameter strings should be `atc`, not `concourse`.
