### PR TITLE
Statically link linux binary

### DIFF
--- a/ci/build-linux
+++ b/ci/build-linux
@@ -16,6 +16,6 @@ go-bindata -nomemcopy -pkg bindata -o gopath/src/github.com/concourse/bin/bindat
 # must be build with 'daemon' flag because of docker packages :|
 go build \
   -tags daemon \
-  -ldflags "-X main.Version=${FINAL_VERSION} -X github.com/concourse/atc/atccmd.Version=${FINAL_VERSION}" \
+  -ldflags "-X main.Version=${FINAL_VERSION} -X github.com/concourse/atc/atccmd.Version=${FINAL_VERSION} -extldflags '-static'" \
   -o binary/concourse_linux_amd64 \
   github.com/concourse/bin/cmd/concourse


### PR DESCRIPTION
Add -extldflags '-static' to the ldflags so that the binary is statically linked.

This allows the binary to execute it very minimal environments, such as Alpine based containers.
