### PR TITLE
Very minor "go vet" fixes (Obvious Fix)

### DIFF
--- a/cmd/concourse/beacon.go
+++ b/cmd/concourse/beacon.go
@@ -144,8 +144,6 @@ func (beacon *Beacon) run(command string, client *ssh.Client, signals <-chan os.
 	case err := <-keepaliveFailed:
 		return err
 	}
-
-	return nil
 }
 
 func (beacon *Beacon) keepAlive(conn ssh.Conn) (<-chan error, chan<- struct{}) {

--- a/cmd/concourse/beacon_config.go
+++ b/cmd/concourse/beacon_config.go
@@ -46,7 +46,7 @@ func (config BeaconConfig) Dial() (*ssh.Client, error) {
 
 	clientConn, chans, reqs, err := ssh.NewClientConn(conn, tsaAddr, clientConfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to construct client connection:", err)
+		return nil, fmt.Errorf("failed to construct client connection: %s", err)
 	}
 
 	return ssh.NewClient(clientConn, chans, reqs), nil


### PR DESCRIPTION
These are two very minor fixes, found by "go vet" after I noticed a malformed error message in the log:
- fix `Printf` format string for an error message (missing `%s` token)
- remove an unreachable `return` statement