### PR TITLE
The web command no longer brings up the TSA when running migration commands

### DIFF
--- a/cmd/concourse/web.go
+++ b/cmd/concourse/web.go
@@ -55,9 +55,13 @@ func (cmd *WebCommand) Runner(args []string) (ifrit.Runner, error) {
 
 	cmd.populateTSAFlagsFromATCFlags()
 
-	atcRunner, err := cmd.ATCCommand.Runner(args)
+	atcRunner, shouldSkipTSA, err := cmd.ATCCommand.Runner(args)
 	if err != nil {
 		return nil, err
+	}
+
+	if shouldSkipTSA {
+		return atcRunner, nil
 	}
 
 	tsaRunner, err := cmd.TSACommand.Runner(args)


### PR DESCRIPTION
This should fix concourse/concourse#2261.