### PR TITLE
Update build-windows.bat to prevent go build failure

### DIFF
--- a/ci/build-windows.bat
+++ b/ci/build-windows.bat
@@ -18,6 +18,8 @@ go build -o go-bindata.exe github.com/jteeuwen/go-bindata/go-bindata
 go build -o packr.exe github.com/gobuffalo/packr/packr
 .\packr.exe -i concourse/src/github.com/concourse
 
-go build -ldflags "-X main.Version=%FinalVersion% -X github.com/concourse/atc/atccmd.Version=%FinalVersion% -X github.com/concourse/atc/atccmd.WorkerVersion=%WorkerVersion% -X main.WorkerVersion=%WorkerVersion%" -o .\binary\concourse_windows_amd64.exe github.com/concourse/bin/cmd/concourse
+go build -ldflags "-X main.Version=%FinalVersion% -X github.com/concourse/atc/atccmd.Version=%FinalVersion% -X github.com/concourse/atc/atccmd.WorkerVersion=%WorkerVersion% -X main.WorkerVersion=%WorkerVersion%" -o concourse_windows_amd64.exe github.com/concourse/bin/cmd/concourse
+
+powershell.exe Copy-Item concourse_windows_amd64.exe binary/
 
 certUtil -hashfile .\binary\concourse_windows_amd64.exe SHA1 > .\binary\concourse_windows_amd64.exe.sha1


### PR DESCRIPTION
Signed-off-by: Ciro S. Costa <cscosta@pivotal.io>
Co-authored-by: Sameer Vohra <svohra@pivotal.io>