### PR TITLE
Update build-linux to include newer init src code

### DIFF
--- a/scripts/build-linux
+++ b/scripts/build-linux
@@ -32,7 +32,7 @@ pushd garden-runc-release/
     go build -o $ASSETS_DIR/bin/dadoo code.cloudfoundry.org/guardian/cmd/dadoo
 
     pushd src/code.cloudfoundry.org/guardian/cmd/init
-      gcc -static -o $ASSETS_DIR/bin/init init.c
+      gcc -static -o $ASSETS_DIR/bin/init init.c ignore_sigchild.c
     popd
 
     pushd src/github.com/opencontainers/runc


### PR DESCRIPTION
To manually verify this, using a Linux machine (or a container):

- clone guardian
- run the command 😁 

Signed-off-by: Ciro S. Costa <cscosta@pivotal.io>
Co-authored-by: Sameer Vohra <svohra@pivotal.io>