### PR TITLE
unmount the /tmp/devices-cgroup so runc is happy

### DIFF
--- a/ci/testflight
+++ b/ci/testflight
@@ -59,6 +59,8 @@ function permit_device_control() {
   # ignore failure in case something has already done this; echo appears to
   # return EINVAL, possibly because devices this affects are already in use
   echo a > ${cgroup_dir}${devices_subdir}/devices.allow || true
+
+  umount "$cgroup_dir"
 }
 
 function containers_gone_wild() {


### PR DESCRIPTION
turns out runc finds this and starts trying to use it as its cgroup
mount

Signed-off-by: Ciro S. Costa <cscosta@pivotal.io>
Co-authored-by: Topher Bullock <cbullock@pivotal.io>